### PR TITLE
Fixes 'license should be a valid SPDX license expression' error

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "git+https://github.com/GoogleChrome/airhorn.git"
   },
   "author": "Paul Kinlan",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/GoogleChrome/airhorn/issues"
   },


### PR DESCRIPTION
When running `npm i`, the following error shows:

`npm WARN airhorn@1.0.0 license should be a valid SPDX license expression`

Fixed by renaming the license to `Apache-2.0`