### PR TITLE
Add simple express server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ simple execute the following command from the root directory:
 
 ## Running
 
-There are number of ways to run Airhorner.  The simplest (if you have Python installed) is to
-start a simple web server up is to use Python's SimpleHTTPServer.  Run the following:
+There are number of ways to run Airhorner.  The simplest is to run the included simple express server
 
-    cd app && python -m SimpleHTTPServer 3000
+    npm install --production && npm start
 
 This will just load the existing contents of the directory up and it won't support things like live
 reload and inline optimizations.  To run the project with optimizations in place and to support live reload

--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "airhorn",
   "version": "1.0.0",
   "description": "A sample web app that lets you use your site as an airhorn.",
+  "scripts": {
+    "start": "node srcServer.js"
+  },
+  "dependencies": {
+    "express": "^4.16.3"
+  },
   "devDependencies": {
     "browser-sync": "^2.7.13",
     "comlinkjs": "^2.2.0",

--- a/srcServer.js
+++ b/srcServer.js
@@ -1,0 +1,14 @@
+var express = require('express');
+var path = require('path');
+
+var port = 3030;
+var app = express();
+
+app.get('/', function(req, res) {
+  res.sendFile(path.join(__dirname, './app/index.html'));
+});
+
+app.use(express.static('app'))
+
+app.listen(port);
+console.log('Listening on port ' + port);


### PR DESCRIPTION
The python server suggested in the [tutorial] serves the `sw.js` service worker file (the crux of this tutorial) with a `content-type=text/plain` header instead of the required `content-type=application/json; charset=UTF-8`.  This causes chrome to give an error:

```
DOMException: Failed to register a ServiceWorker: The script has an unsupported MIME type ('text/plain').
```

I have added a very simple express server to this repo that fixes that issue by serving the file with the proper `content-type`.

[tutorial]: https://developers.google.com/web/fundamentals/codelabs/offline/