### PR TITLE
Use passive event listeners when supported

### DIFF
--- a/app/scripts/main.min.js
+++ b/app/scripts/main.min.js
@@ -217,8 +217,22 @@ const AirHorn = function(root) {
     horn.stop();
   };
 
-  airhornImage.addEventListener('mousedown', start.bind(this));
-  airhornImage.addEventListener('touchstart', start.bind(this));
+  // Test to see if passive events listener are supported.
+  let supportsPassive = false;
+  try {
+    const opts = Object.defineProperty({}, 'passive', {
+      get: function() {
+        supportsPassive = true;
+      }
+    });
+    window.addEventListener('testPassive', null, opts);
+    window.removeEventListener('testPassive', null, opts);
+  } catch (e) {}
+
+  airhornImage.addEventListener('mousedown', start.bind(this),
+      supportsPassive ? { passive: true } : false);
+  airhornImage.addEventListener('touchstart', start.bind(this),
+      supportsPassive ? { passive: true } : false);
 
   document.documentElement.addEventListener('mouseup', stop.bind(this));
   document.documentElement.addEventListener('touchend', stop.bind(this));


### PR DESCRIPTION
This CL makes sure airhorner hits 100% in best practises by using passive event listeners when supported.

![image](https://user-images.githubusercontent.com/634478/38235785-a1ed5884-3722-11e8-9ad4-d6e055fc3965.png)

R: @PaulKinlan 