### PR TITLE
Fix - Missing coma in the callback

### DIFF
--- a/app/scripts/main.min.js
+++ b/app/scripts/main.min.js
@@ -217,7 +217,7 @@ const AirHorn = function(root) {
     if (window.opener) {
       window.opener.postMessage({
         'action': 'airhorn-played',
-        'count': counter
+        'count': counter,
         'url': 'https://airhorner.com/'
       }, 'https://developer.chrome.com/devsummit/adventure/')
     }


### PR DESCRIPTION
Missing coma in the callback for Adventure to trigger swag